### PR TITLE
inconsistent formatting; change tabs to spaces

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
 
+2.21 - August 14th, 2014
+
+  - Declare CGI.pm as a testing dependency (RT #98012, thanks to Martin McGrath)
+
 2.20 - August 10th, 2013
 
     - Updated to support HTML5 (RT #75933, thanks to charsbar)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,44 @@
+This program is free software; you can redistribute it and/or modify
+it under the terms of either:
+
+	a) the GNU General Public License as published by the Free
+	Software Foundation; either version 1, or (at your option) any
+	later version, or
+
+	b) the "Artistic License" which comes with this Kit.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See either
+the GNU General Public License or the Artistic License for more details.
+
+You should have received a copy of the Artistic License with this
+Kit, in the file named "Artistic".  If not, I'll be glad to provide one.
+
+You should also have received a copy of the GNU General Public License
+along with this program in the file named "Copying". If not, write to the
+Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+Boston, MA 02110-1301, USA or visit their web page on the internet at
+http://www.gnu.org/copyleft/gpl.html.
+
+For those of you that choose to use the GNU General Public License,
+my interpretation of the GNU General Public License is that no Perl
+script falls under the terms of the GPL unless you explicitly put
+said script under the terms of the GPL yourself.  Furthermore, any
+object code linked with perl does not automatically fall under the
+terms of the GPL, provided such object code only adds definitions
+of subroutines and variables, and does not otherwise impair the
+resulting interpreter from executing any standard Perl script.  I
+consider linking in C subroutines in this manner to be the moral
+equivalent of defining subroutines in the Perl language itself.  You
+may sell such an object file as proprietary provided that you provide
+or offer to provide the Perl source, as specified by the GNU General
+Public License.  (This is merely an alternate way of specifying input
+to the program.)  You may also sell a binary produced by the dumping of
+a running Perl script that belongs to you, provided that you provide or
+offer to provide the Perl source as specified by the GPL.  (The
+fact that a Perl interpreter and your code are in the same binary file
+is, in this case, a form of mere aggregation.)  This is my interpretation
+of the GPL.  If you still have concerns or difficulties understanding
+my intent, feel free to contact me.  Of course, the Artistic License
+spells all this out for your protection, so you may prefer to use that.

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,5 @@
 Changes
+LICENSE
 MANIFEST
 Makefile.PL
 META.yml			Module meta-data (added by MakeMaker)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,5 +8,15 @@ WriteMakefile(
 	HTML::Parser => 3.26,
 	HTML::TokeParser => 3.26,
         warnings => 0
-      },
+    },
+    META_MERGE		=> {
+        'meta-spec' => { version => 2 },
+        resources => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/markstos/HTML-FillInForm.git',
+                web  => 'https://github.com/markstos/HTML-FillInForm',
+            },
+        },
+    },
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,12 +5,15 @@ WriteMakefile(
     'NAME'		=> 'HTML::FillInForm',
     'VERSION_FROM'	=> 'lib/HTML/FillInForm.pm', # finds $VERSION
     'PREREQ_PM'		=> {
-	HTML::Parser => 3.26,
-	HTML::TokeParser => 3.26,
+        Carp => 0,
+        HTML::Parser => 3.26,
+        HTML::TokeParser => 3.26,
         warnings => 0
     },
     TEST_REQUIRES => {
-        CGI => 0
+        CGI => 0,
+	Test => 0,
+	Test::More => 0,
     },
     META_MERGE		=> {
         'meta-spec' => { version => 2 },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,6 +9,9 @@ WriteMakefile(
 	HTML::TokeParser => 3.26,
         warnings => 0
     },
+    TEST_REQUIRES => {
+        CGI => 0
+    },
     META_MERGE		=> {
         'meta-spec' => { version => 2 },
         resources => {

--- a/README
+++ b/README
@@ -1,14 +1,31 @@
-This module automatically inserts data from a previous HTML form into the HTML input and select
-tags. It is a subclass of HTML::Parser and uses it to parse the HTML and insert the values into the form
-tags.
+This module automatically inserts data from a previous HTML form into
+the HTML input and select tags. It is a subclass of HTML::Parser and
+uses it to parse the HTML and insert the values into the form tags.
 
-One useful application is after a user submits an HTML form without filling out required field.
-HTML::FillInForm can be used to redisplay the HTML form with all the form elements containing the
-submitted info.
+One useful application is after a user submits an HTML form without
+filling out required field. HTML::FillInForm can be used to redisplay
+the HTML form with all the form elements containing the submitted info.
 
 Please note that this module requires HTML::Parser 3.26 or greater.
 
-HTML::FillInForm installed by default by several web hosting providers,
+
+To install this module, use CPAN, for example:
+
+  cpan HTML::FillInForm
+
+To isntead build this software from source, run:
+
+  perl Makefile.PL
+  make
+  make test
+  make install
+
+After installing, you can read the documentation for this module via:
+
+  perldoc HTML::FillInForm
+
+
+HTML::FillInForm is installed by default by several web hosting providers,
 including pair.com - see
 http://www.pair.com/pair/support/library/serverconfig/perlmods.html
 

--- a/README
+++ b/README
@@ -13,7 +13,7 @@ To install this module, use CPAN, for example:
 
   cpan HTML::FillInForm
 
-To isntead build this software from source, run:
+To instead build this software from source, run:
 
   perl Makefile.PL
   make

--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -321,7 +321,7 @@ sub start {
     $self->{output} .= ' /' if $attr->{'/'};
     $self->{output} .= ">";
   } elsif ($tagname eq 'option'){
-    my $value = $self->_get_param($self->{selectName});
+    my $value = defined($self->{selectName}) ? $self->_get_param($self->{selectName}) : undef;
 
     # browsers do not pass selects with no selected options at all,
     # so hack around

--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -167,7 +167,7 @@ sub fill {
     for my $object (@$objects){
       # make sure objects in 'param_object' parameter support param()
       defined($object->can('param')) or
-	croak("HTML::FillInForm->fill called with fobject option, containing object of type " . ref($object) . " which lacks a param() method!");
+        croak("HTML::FillInForm->fill called with fobject option, containing object of type " . ref($object) . " which lacks a param() method!");
     }
 
     $self->{objects} = $objects;
@@ -273,45 +273,48 @@ sub start {
     if (defined($value)){
       # check for input type, noting that default type is text
       if (!exists $attr->{'type'} ||
-	  $attr->{'type'} =~ /^(text|textfield|hidden|tel|search|url|email|datetime|date|month|week|time|datetime\-local|number|range|color|)$/i){
-	if ( ref($value) eq 'ARRAY' ) {
-	  $value = shift @$value;
-	  $value = '' unless defined $value;
+          $attr->{'type'} =~ /^(text|textfield|hidden|tel|search|url|email|datetime|date|month|week|time|datetime\-local|number|range|color|)$/i) {
+        if ( ref($value) eq 'ARRAY' ) {
+          $value = shift @$value;
+          $value = '' unless defined $value;
         }
-	$attr->{'value'} = __escapeHTML($value);
+        $attr->{'value'} = __escapeHTML($value);
       } elsif (lc $attr->{'type'} eq 'password' && $self->{fill_password}) {
-	if ( ref($value) eq 'ARRAY' ) {
-	  $value = shift @$value;
-	  $value = '' unless defined $value;
+        if ( ref($value) eq 'ARRAY' ) {
+          $value = shift @$value;
+          $value = '' unless defined $value;
         }
-	$attr->{'value'} = __escapeHTML($value);
+        $attr->{'value'} = __escapeHTML($value);
       } elsif (lc $attr->{'type'} eq 'radio'){
-	if ( ref($value) eq 'ARRAY' ) {
-	  $value = $value->[0];
-	  $value = '' unless defined $value;
+        if ( ref($value) eq 'ARRAY' ) {
+          $value = $value->[0];
+          $value = '' unless defined $value;
         }
-	# value for radio boxes default to 'on', works with netscape
-	$attr->{'value'} = 'on' unless exists $attr->{'value'};
-	if ($attr->{'value'} eq __escapeHTML($value)){
-	  $attr->{'checked'} = 'checked';
-	} else {
-	  delete $attr->{'checked'};
-	}
-      } elsif (lc $attr->{'type'} eq 'checkbox'){
-	# value for checkboxes default to 'on', works with netscape
-	$attr->{'value'} = 'on' unless exists $attr->{'value'};
 
-	delete $attr->{'checked'}; # Everything is unchecked to start
+        # value for radio boxes default to 'on', works with netscape
+        $attr->{'value'} = 'on' unless exists $attr->{'value'};
+        if ($attr->{'value'} eq __escapeHTML($value)){
+          $attr->{'checked'} = 'checked';
+        } else {
+          delete $attr->{'checked'};
+        }
+      } elsif (lc $attr->{'type'} eq 'checkbox'){
+        # value for checkboxes default to 'on', works with netscape
+        $attr->{'value'} = 'on' unless exists $attr->{'value'};
+
+        delete $attr->{'checked'}; # Everything is unchecked to start
         $value = [ $value ] unless ref($value) eq 'ARRAY';
-	foreach my $v ( @$value ) {
-	  if ( $attr->{'value'} eq __escapeHTML($v) ) {
-	    $attr->{'checked'} = 'checked';
-	  }
-	}
-#      } else {
-#	warn(qq(Input field of unknown type "$attr->{type}": $origtext));
+        foreach my $v ( @$value ) {
+          if ( $attr->{'value'} eq __escapeHTML($v) ) {
+            $attr->{'checked'} = 'checked';
+          }
+        }
+
+        #      } else {
+        # warn(qq(Input field of unknown type "$attr->{type}": $origtext));
       }
     }
+
     $self->{output} .= "<$tagname";
     while (my ($key, $value) = each %$attr) {
       next if $key eq '/';
@@ -329,18 +332,18 @@ sub start {
 
     $value = [ $value ] unless ( ref($value) eq 'ARRAY' );
 
-    if ( defined $value->[0] ){
+    if (defined $value->[0]) {
       delete $attr->{selected} if exists $attr->{selected};
       
-      if(defined($attr->{'value'})){
+      if (defined($attr->{'value'})) {
         # option tag has value attr - <OPTION VALUE="foo">bar</OPTION>
         
         if ($self->{selectMultiple}){
           # check if the option tag belongs to a multiple option select
-	  foreach my $v ( grep { defined } @$value ) {
-	    if ( $attr->{'value'} eq __escapeHTML($v) ){
-	      $attr->{selected} = 'selected';
-	    }
+          foreach my $v ( grep { defined } @$value ) {
+            if ( $attr->{'value'} eq __escapeHTML($v) ){
+              $attr->{selected} = 'selected';
+            }
           }
         } else {
           # if not every value of a fdat ARRAY belongs to a different select tag
@@ -354,8 +357,8 @@ sub start {
         }
       } else {
         # option tag has no value attr - <OPTION>bar</OPTION>
-	# save for processing under text handler
-	$self->{option_no_value} = __escapeHTML($value);
+        # save for processing under text handler
+        $self->{option_no_value} = __escapeHTML($value);
       }
     }
     $self->{output} .= "<$tagname";
@@ -446,8 +449,8 @@ sub text {
       $value =~ s/^\s+//;
       $value =~ s/\s+$//;
       foreach my $v ( @$values ) {
-	if ( $value eq $v ) {
-	  $self->{output} .= ' selected="selected"';
+        if ( $value eq $v ) {
+          $self->{output} .= ' selected="selected"';
         }
       }
       # close <OPTION> tag

--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -348,7 +348,7 @@ sub start {
 	    if ( $attr->{'value'} eq __escapeHTML($value->[0])){
 	      shift @$value if ref($value) eq 'ARRAY';
 	      $attr->{selected} = 'selected';
-              $self->{selectSelected} = 1; # remeber that an option tag is selected for this select tag
+              $self->{selectSelected} = 1; # remember that an option tag is selected for this select tag
 	    }
           }
         }

--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -167,7 +167,7 @@ sub fill {
     for my $object (@$objects){
       # make sure objects in 'param_object' parameter support param()
       defined($object->can('param')) or
-        croak("HTML::FillInForm->fill called with fobject option, containing object of type " . ref($object) . " which lacks a param() method!");
+	croak("HTML::FillInForm->fill called with fobject option, containing object of type " . ref($object) . " which lacks a param() method!");
     }
 
     $self->{objects} = $objects;
@@ -273,48 +273,45 @@ sub start {
     if (defined($value)){
       # check for input type, noting that default type is text
       if (!exists $attr->{'type'} ||
-          $attr->{'type'} =~ /^(text|textfield|hidden|tel|search|url|email|datetime|date|month|week|time|datetime\-local|number|range|color|)$/i) {
-        if ( ref($value) eq 'ARRAY' ) {
-          $value = shift @$value;
-          $value = '' unless defined $value;
+	  $attr->{'type'} =~ /^(text|textfield|hidden|tel|search|url|email|datetime|date|month|week|time|datetime\-local|number|range|color|)$/i){
+	if ( ref($value) eq 'ARRAY' ) {
+	  $value = shift @$value;
+	  $value = '' unless defined $value;
         }
-        $attr->{'value'} = __escapeHTML($value);
+	$attr->{'value'} = __escapeHTML($value);
       } elsif (lc $attr->{'type'} eq 'password' && $self->{fill_password}) {
-        if ( ref($value) eq 'ARRAY' ) {
-          $value = shift @$value;
-          $value = '' unless defined $value;
+	if ( ref($value) eq 'ARRAY' ) {
+	  $value = shift @$value;
+	  $value = '' unless defined $value;
         }
-        $attr->{'value'} = __escapeHTML($value);
+	$attr->{'value'} = __escapeHTML($value);
       } elsif (lc $attr->{'type'} eq 'radio'){
-        if ( ref($value) eq 'ARRAY' ) {
-          $value = $value->[0];
-          $value = '' unless defined $value;
+	if ( ref($value) eq 'ARRAY' ) {
+	  $value = $value->[0];
+	  $value = '' unless defined $value;
         }
-
-        # value for radio boxes default to 'on', works with netscape
-        $attr->{'value'} = 'on' unless exists $attr->{'value'};
-        if ($attr->{'value'} eq __escapeHTML($value)){
-          $attr->{'checked'} = 'checked';
-        } else {
-          delete $attr->{'checked'};
-        }
+	# value for radio boxes default to 'on', works with netscape
+	$attr->{'value'} = 'on' unless exists $attr->{'value'};
+	if ($attr->{'value'} eq __escapeHTML($value)){
+	  $attr->{'checked'} = 'checked';
+	} else {
+	  delete $attr->{'checked'};
+	}
       } elsif (lc $attr->{'type'} eq 'checkbox'){
-        # value for checkboxes default to 'on', works with netscape
-        $attr->{'value'} = 'on' unless exists $attr->{'value'};
+	# value for checkboxes default to 'on', works with netscape
+	$attr->{'value'} = 'on' unless exists $attr->{'value'};
 
-        delete $attr->{'checked'}; # Everything is unchecked to start
+	delete $attr->{'checked'}; # Everything is unchecked to start
         $value = [ $value ] unless ref($value) eq 'ARRAY';
-        foreach my $v ( @$value ) {
-          if ( $attr->{'value'} eq __escapeHTML($v) ) {
-            $attr->{'checked'} = 'checked';
-          }
-        }
-
-        #      } else {
-        # warn(qq(Input field of unknown type "$attr->{type}": $origtext));
+	foreach my $v ( @$value ) {
+	  if ( $attr->{'value'} eq __escapeHTML($v) ) {
+	    $attr->{'checked'} = 'checked';
+	  }
+	}
+#      } else {
+#	warn(qq(Input field of unknown type "$attr->{type}": $origtext));
       }
     }
-
     $self->{output} .= "<$tagname";
     while (my ($key, $value) = each %$attr) {
       next if $key eq '/';
@@ -332,18 +329,18 @@ sub start {
 
     $value = [ $value ] unless ( ref($value) eq 'ARRAY' );
 
-    if (defined $value->[0]) {
+    if ( defined $value->[0] ){
       delete $attr->{selected} if exists $attr->{selected};
       
-      if (defined($attr->{'value'})) {
+      if(defined($attr->{'value'})){
         # option tag has value attr - <OPTION VALUE="foo">bar</OPTION>
         
         if ($self->{selectMultiple}){
           # check if the option tag belongs to a multiple option select
-          foreach my $v ( grep { defined } @$value ) {
-            if ( $attr->{'value'} eq __escapeHTML($v) ){
-              $attr->{selected} = 'selected';
-            }
+	  foreach my $v ( grep { defined } @$value ) {
+	    if ( $attr->{'value'} eq __escapeHTML($v) ){
+	      $attr->{selected} = 'selected';
+	    }
           }
         } else {
           # if not every value of a fdat ARRAY belongs to a different select tag
@@ -357,8 +354,8 @@ sub start {
         }
       } else {
         # option tag has no value attr - <OPTION>bar</OPTION>
-        # save for processing under text handler
-        $self->{option_no_value} = __escapeHTML($value);
+	# save for processing under text handler
+	$self->{option_no_value} = __escapeHTML($value);
       }
     }
     $self->{output} .= "<$tagname";
@@ -449,8 +446,8 @@ sub text {
       $value =~ s/^\s+//;
       $value =~ s/\s+$//;
       foreach my $v ( @$values ) {
-        if ( $value eq $v ) {
-          $self->{output} .= ' selected="selected"';
+	if ( $value eq $v ) {
+	  $self->{output} .= ' selected="selected"';
         }
       }
       # close <OPTION> tag

--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -754,6 +754,13 @@ L<http://www.perlmonks.org/index.pl?node_id=274534>
 All rights reserved. This package is free software; you can
 redistribute it and/or modify it under the same terms as Perl itself.
 
+=head1 LICENSE
+
+Copyright (c) 2002-2007 Thomas J. Mather, tjmather@maxmind.com 
+
+All rights reserved. This package is free software; you can redistribute
+it and/or modify it under the same terms as Perl itself. 
+
 =head1 SEE ALSO
 
 L<HTML::Parser|HTML::Parser>, 

--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -10,7 +10,7 @@ use Carp; # generate better errors with more context
 require 5.005;
 
 use vars qw($VERSION @ISA);
-$VERSION = '2.20';
+$VERSION = '2.21';
 
 
 sub new {

--- a/t/10_escape.t
+++ b/t/10_escape.t
@@ -37,3 +37,7 @@ my $strings_html = join("\n", sort split(/[\s><]+/, lc($html)));
 
 is($strings_output,$strings_html);
 
+
+$html = q{<form><input name="foo" value='"quoted"'>};
+$output = HTML::FillInForm->fill(\$html, {});
+like $output, qr/value="&quot;quoted&quot;"/, 'unescaped values are escaped';


### PR DESCRIPTION
There was inconsistent formatting in the current version, using spaces in most of the module but tabs in a few areas. This cleans that up, replacing all tabs with spaces.
