### PR TITLE
Experimental

### DIFF
--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -43,23 +43,23 @@ sub fill_scalarref { my $self = shift; return $self->fill('scalarref',@_); }
 
 # track the keys we support. Useful for file-name detection.
 sub _known_keys {
-    return {
-        scalarref      =>  1,
-        arrayref       =>  1,
-        fdat           =>  1,
-        fobject        =>  1,
-        file           =>  1,
-        target         =>  1,
-        fill_password  =>  1,
-        ignore_fields  =>  1,
-        disable_fields =>  1,
-        invalid_fields =>  1,
-        invalid_class  =>  1,
-    }
+  return {
+    scalarref      =>  1,
+    arrayref       =>  1,
+    fdat           =>  1,
+    fobject        =>  1,
+    file           =>  1,
+    target         =>  1,
+    fill_password  =>  1,
+    ignore_fields  =>  1,
+    disable_fields =>  1,
+    invalid_fields =>  1,
+    invalid_class  =>  1,
+  }
 }
 
 sub fill {
-   my $self = shift;
+  my $self = shift;
 
   # If we are called as a class method, go ahead and call new().
   $self = $self->new if (not ref $self);
@@ -69,67 +69,55 @@ sub fill {
   # If the first arg is a scalarref, translate that to scalarref => $first_arg
   if (ref $_[0] eq 'SCALAR') {
       $option{scalarref} = shift;
-  }
-  elsif (ref $_[0] eq 'ARRAY') {
+  } elsif (ref $_[0] eq 'ARRAY') {
       $option{arrayref} = shift;
-  }
-  elsif (ref $_[0] eq 'GLOB') {
+  } elsif (ref $_[0] eq 'GLOB') {
       $option{file} = shift;
-  }
-  elsif (ref $_[0]) {
+  } elsif (ref $_[0]) {
     croak "data source is not a reference type we understand";
   }
   # Last chance, if the first arg isn't one of the known keys, we 
   # assume it is a file name.
   elsif (not _known_keys()->{$_[0]} )  {
     $option{file} =  shift;
-  }
-  else {
+  } else {
       # Should be a known key. Nothing to do.
   }
-
 
   # Now, check to see if the next arg is also a reference. 
   my $data;
   if (ref $_[0]) {
-      $data = shift;
-      $data = [$data] unless ref $data eq 'ARRAY';
+    $data = shift;
+    $data = [$data] unless ref $data eq 'ARRAY';
 
-      for my $source (@$data) {
-          if (ref $source eq 'HASH') {
-              push @{ $option{fdat} }, $source;
-          }
-          elsif (ref $source) {
-              if ($source->can('param')) {
-                  push @{ $option{fobject} }, $source;
-              }
-              else {
-                  croak "data source $source does not supply a param method";
-              }
-          }
-          elsif (defined $source) {
-              croak "data source $source is not a hash or object reference";
-          }
+    for my $source (@$data) {
+      if (ref $source eq 'HASH') {
+        push @{ $option{fdat} }, $source;
+      } elsif (ref $source) {
+        if ($source->can('param')) {
+          push @{ $option{fobject} }, $source;
+        } else {
+          croak "data source $source does not supply a param method";
+        }
+      } elsif (defined $source) {
+        croak "data source $source is not a hash or object reference";
       }
-
+    }
   }
-
  
   # load in the rest of the options
   %option = (%option, @_);
 
-
   # As suggested in the docs, merge multiple fdats into one. 
   if (ref $option{fdat} eq 'ARRAY') {
-      my %merged;
-      for my $hash (@{ $option{fdat} }) {
-          for my $key (keys %$hash) {
-              $merged{$key} = $hash->{$key};
-          }
+    my %merged;
+    for my $hash (@{ $option{fdat} }) {
+      for my $key (keys %$hash) {
+        $merged{$key} = $hash->{$key};
       }
-      $option{'fdat'} = \%merged;
+    }
+    $option{'fdat'} = \%merged;
   }
-
 
   my %ignore_fields;
   %ignore_fields = map { $_ => 1 } ( ref $option{'ignore_fields'} eq 'ARRAY' )
@@ -160,11 +148,11 @@ sub fill {
   # We want the reference to these objects to go out of scope at the
   # end of the method.
   local $self->{objects} = [];
-  if(my $objects = $option{fobject}){
-    unless(ref($objects) eq 'ARRAY'){
+  if (my $objects = $option{fobject}) {
+    unless (ref($objects) eq 'ARRAY') {
       $objects = [ $objects ];
     }
-    for my $object (@$objects){
+    for my $object (@$objects) {
       # make sure objects in 'param_object' parameter support param()
       defined($object->can('param')) or
         croak("HTML::FillInForm->fill called with fobject option, containing object of type " . ref($object) . " which lacks a param() method!");
@@ -172,17 +160,18 @@ sub fill {
 
     $self->{objects} = $objects;
   }
-  if (my $target = $option{target}){
+
+  if (my $target = $option{target}) {
     $self->{'target'} = $target;
   }
 
-  if (my $invalid_class = $option{invalid_class}){
+  if (my $invalid_class = $option{invalid_class}) {
     $self->{'invalid_class'} = $invalid_class;
   } else {
     $self->{'invalid_class'} = 'invalid';
   }
 
-  if (defined($option{fill_password})){
+  if (defined($option{fill_password})) {
     $self->{fill_password} = $option{fill_password};
   } else {
     $self->{fill_password} = 1;
@@ -191,18 +180,19 @@ sub fill {
   $self->{clear_absent_checkboxes} = $option{clear_absent_checkboxes};
 
   # make sure method has data to fill in HTML form with!
-  unless(exists $self->{fdat} || $self->{objects}){
-    croak("HTML::FillInForm->fillInForm() called without 'fobject' or 'fdat' parameter set");
+  unless (exists $self->{fdat} || $self->{objects}) {
+    croak "HTML::FillInForm->fillInForm() called without 'fobject' or " .
+          "'fdat' parameter set";
   }
 
   local $self->{object_param_cache};
 
-  if(my $file = $option{file}){
+  if (my $file = $option{file}) {
     $self->parse_file($file);
-  } elsif (my $scalarref = $option{scalarref}){
+  } elsif (my $scalarref = $option{scalarref}) {
     $self->parse($$scalarref);
-  } elsif (my $arrayref = $option{arrayref}){
-    for (@$arrayref){
+  } elsif (my $arrayref = $option{arrayref}) {
+    for (@$arrayref) {
       $self->parse($_);
     }
   }
@@ -226,15 +216,14 @@ sub start {
     }
   }
 
-  # This form is not my target.
+  # This form is not my target
   if (exists $self->{'target'} &&
-      (! exists $self->{'current_form'} ||
+       (! exists $self->{'current_form'} ||
        $self->{'current_form'} ne $self->{'target'})) {
     $self->{'output'} .= $origtext;
     return;
   }
   
-  # HTML::Parser converts tagname to lowercase, so we don't need /i
   if ($self->{option_no_value}) {
     $self->{output} .= '>';
     delete $self->{option_no_value};

--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -249,7 +249,7 @@ sub start {
 
   # XXX  
   if ($self->{option_no_value}) {
-    # $self->{output} .= '>';
+    $self->{output} .= '>';
     delete $self->{option_no_value};
   }
 

--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -245,13 +245,7 @@ sub start {
     delete $self->{open}{option};
   }
 
-  #$self->{open}{ $tagname } = { attr => $attr, origtext => $origtext };
-
-  # XXX  
-  if ($self->{option_no_value}) {
-    $self->{output} .= '>';
-    delete $self->{option_no_value};
-  }
+  $self->{open}{ $tagname } = { attr => $attr, origtext => $origtext };
 
   # Check if we need to disable this field
   $attr->{disabled} = 'disabled'
@@ -346,7 +340,8 @@ sub start {
     $self->{output} .= ' /' if $attr->{'/'};
     $self->{output} .= ">";
   } elsif ($tagname eq 'option'){
-    my $value = $self->_get_param($self->{selectName});
+    my $select_name =$self->{open}{select}{attr}{name};
+    my $value = $self->_get_param( $select_name );
 
     # browsers do not pass selects with no selected options at all,
     # so hack around
@@ -413,7 +408,6 @@ sub start {
       $self->{output} .= __escapeHTML($value);
     }
   } elsif ($tagname eq 'select') {
-    $self->{selectName} = $attr->{'name'};
     if (defined $attr->{'multiple'}) {
       $self->{selectMultiple} = 1; # helper var to remember if the select tag has the multiple attr set or not
     } else {
@@ -502,6 +496,8 @@ sub end {
   } elsif ($tagname eq 'form') {
     delete $self->{'current_form'};
   }
+
+  delete $self->{open}{ $tagname };
 
   $self->{output} .= $origtext;
 }

--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -404,7 +404,7 @@ sub start {
       $value = (shift @$value || '') if ref($value) eq 'ARRAY';
       # <textarea> foobar </textarea> -> <textarea> $value </textarea>
       # we need to set outputText to 'no' so that 'foobar' won't be printed
-      $self->{outputText} = 'no';
+      $self->{open}{textarea}{suppress_content} = 1;
       $self->{output} .= __escapeHTML($value);
     }
   } elsif ($tagname eq 'select') {
@@ -458,7 +458,8 @@ sub text {
   my ($self, $origtext) = @_;
 
   # if textarea value has changed, don't output it
-  return if exists $self->{outputText} && $self->{outputText} eq 'no';
+  my $textarea = $self->{open}{textarea};
+  return if $textarea && $textarea->{suppress_content};
 
   # dealing with option tag with no value - <OPTION>bar</OPTION>
   if (my $values = $self->{option_no_value}) {
@@ -489,14 +490,7 @@ sub end {
     delete $self->{option_no_value};
   }
 
-  if ($tagname eq 'select') {
-    delete $self->{selectName};
-  } elsif ($tagname eq 'textarea'){
-    delete $self->{outputText};
-  } elsif ($tagname eq 'form') {
-    delete $self->{'current_form'};
-  }
-
+  delete $self->{current_form} if $tagname eq 'form';
   delete $self->{open}{ $tagname };
 
   $self->{output} .= $origtext;

--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -242,7 +242,9 @@ sub _write_tag {
   my $self = shift;
   my $tag = shift or croak "no tag supplied";
 
-  $tag = $self->_tag($tag) || {} unless ref $tag;
+  unless (ref $tag) {
+    $tag = $self->_tag($tag) or return;
+  }
   my $attr = $tag->{attr} || {};
 
   $self->{output} .= "<$tag->{tagname}";

--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -385,7 +385,7 @@ sub start {
     # browsers do not pass selects with no selected options at all,
     # so hack around
     $value = '' if $self->{clear_absent_checkboxes} && !defined $value;
-    # squirrel away values array for use in option tags
+    # save selected values for use in option tags
     $tag->{escaped_values} = [
       map { __escapeHTML($_) }
       grep { defined }

--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -167,7 +167,7 @@ sub fill {
     for my $object (@$objects){
       # make sure objects in 'param_object' parameter support param()
       defined($object->can('param')) or
-	croak("HTML::FillInForm->fill called with fobject option, containing object of type " . ref($object) . " which lacks a param() method!");
+        croak("HTML::FillInForm->fill called with fobject option, containing object of type " . ref($object) . " which lacks a param() method!");
     }
 
     $self->{objects} = $objects;
@@ -273,45 +273,48 @@ sub start {
     if (defined($value)){
       # check for input type, noting that default type is text
       if (!exists $attr->{'type'} ||
-	  $attr->{'type'} =~ /^(text|textfield|hidden|tel|search|url|email|datetime|date|month|week|time|datetime\-local|number|range|color|)$/i){
-	if ( ref($value) eq 'ARRAY' ) {
-	  $value = shift @$value;
-	  $value = '' unless defined $value;
+          $attr->{'type'} =~ /^(text|textfield|hidden|tel|search|url|email|datetime|date|month|week|time|datetime\-local|number|range|color|)$/i) {
+        if ( ref($value) eq 'ARRAY' ) {
+          $value = shift @$value;
+          $value = '' unless defined $value;
         }
-	$attr->{'value'} = __escapeHTML($value);
+        $attr->{'value'} = __escapeHTML($value);
       } elsif (lc $attr->{'type'} eq 'password' && $self->{fill_password}) {
-	if ( ref($value) eq 'ARRAY' ) {
-	  $value = shift @$value;
-	  $value = '' unless defined $value;
+        if ( ref($value) eq 'ARRAY' ) {
+          $value = shift @$value;
+          $value = '' unless defined $value;
         }
-	$attr->{'value'} = __escapeHTML($value);
+        $attr->{'value'} = __escapeHTML($value);
       } elsif (lc $attr->{'type'} eq 'radio'){
-	if ( ref($value) eq 'ARRAY' ) {
-	  $value = $value->[0];
-	  $value = '' unless defined $value;
+        if ( ref($value) eq 'ARRAY' ) {
+          $value = $value->[0];
+          $value = '' unless defined $value;
         }
-	# value for radio boxes default to 'on', works with netscape
-	$attr->{'value'} = 'on' unless exists $attr->{'value'};
-	if ($attr->{'value'} eq __escapeHTML($value)){
-	  $attr->{'checked'} = 'checked';
-	} else {
-	  delete $attr->{'checked'};
-	}
-      } elsif (lc $attr->{'type'} eq 'checkbox'){
-	# value for checkboxes default to 'on', works with netscape
-	$attr->{'value'} = 'on' unless exists $attr->{'value'};
 
-	delete $attr->{'checked'}; # Everything is unchecked to start
+        # value for radio boxes default to 'on', works with netscape
+        $attr->{'value'} = 'on' unless exists $attr->{'value'};
+        if ($attr->{'value'} eq __escapeHTML($value)){
+          $attr->{'checked'} = 'checked';
+        } else {
+          delete $attr->{'checked'};
+        }
+      } elsif (lc $attr->{'type'} eq 'checkbox'){
+        # value for checkboxes default to 'on', works with netscape
+        $attr->{'value'} = 'on' unless exists $attr->{'value'};
+
+        delete $attr->{'checked'}; # Everything is unchecked to start
         $value = [ $value ] unless ref($value) eq 'ARRAY';
-	foreach my $v ( @$value ) {
-	  if ( $attr->{'value'} eq __escapeHTML($v) ) {
-	    $attr->{'checked'} = 'checked';
-	  }
-	}
-#      } else {
-#	warn(qq(Input field of unknown type "$attr->{type}": $origtext));
+        foreach my $v ( @$value ) {
+          if ( $attr->{'value'} eq __escapeHTML($v) ) {
+            $attr->{'checked'} = 'checked';
+          }
+        }
+
+        #      } else {
+        # warn(qq(Input field of unknown type "$attr->{type}": $origtext));
       }
     }
+
     $self->{output} .= "<$tagname";
     while (my ($key, $value) = each %$attr) {
       next if $key eq '/';
@@ -329,33 +332,33 @@ sub start {
 
     $value = [ $value ] unless ( ref($value) eq 'ARRAY' );
 
-    if ( defined $value->[0] ){
+    if (defined $value->[0]) {
       delete $attr->{selected} if exists $attr->{selected};
       
-      if(defined($attr->{'value'})){
+      if (defined($attr->{'value'})) {
         # option tag has value attr - <OPTION VALUE="foo">bar</OPTION>
         
         if ($self->{selectMultiple}){
           # check if the option tag belongs to a multiple option select
-	  foreach my $v ( grep { defined } @$value ) {
-	    if ( $attr->{'value'} eq __escapeHTML($v) ){
-	      $attr->{selected} = 'selected';
-	    }
+          foreach my $v ( grep { defined } @$value ) {
+            if ( $attr->{'value'} eq __escapeHTML($v) ){
+              $attr->{selected} = 'selected';
+            }
           }
         } else {
           # if not every value of a fdat ARRAY belongs to a different select tag
           if (not $self->{selectSelected}){
-	    if ( $attr->{'value'} eq __escapeHTML($value->[0])){
-	      shift @$value if ref($value) eq 'ARRAY';
-	      $attr->{selected} = 'selected';
+            if ( $attr->{'value'} eq __escapeHTML($value->[0])){
+              shift @$value if ref($value) eq 'ARRAY';
+              $attr->{selected} = 'selected';
               $self->{selectSelected} = 1; # remeber that an option tag is selected for this select tag
-	    }
+            }
           }
         }
       } else {
         # option tag has no value attr - <OPTION>bar</OPTION>
-	# save for processing under text handler
-	$self->{option_no_value} = __escapeHTML($value);
+        # save for processing under text handler
+        $self->{option_no_value} = __escapeHTML($value);
       }
     }
     $self->{output} .= "<$tagname";
@@ -446,8 +449,8 @@ sub text {
       $value =~ s/^\s+//;
       $value =~ s/\s+$//;
       foreach my $v ( @$values ) {
-	if ( $value eq $v ) {
-	  $self->{output} .= ' selected="selected"';
+        if ( $value eq $v ) {
+          $self->{output} .= ' selected="selected"';
         }
       }
       # close <OPTION> tag


### PR DESCRIPTION
Hi. This branch is a fairly significant refactoring of the module.

I needed to output some additional markup in the case of invalid fields and I couldn't see a clean way to do it with the existing version.

With this version, all altered tags go through the _output_tag method, so we have a centralized place to override it in subclasses. I know performance is a concern so I tried to be mindful of that. Even with the additional method calls this version appears to perform about the same (I think I improved performance in some other areas).

I also tried to simplify some of the logic by changing the way state is maintained for the various tags. See around line #296. We're storing the HTML::Parser data for each tag as we see it start, which lets us reference it from other tags. That gets rid of a bunch of state variables and makes it simpler to follow IMO.
