### PR TITLE
Don't call _get_param(undef) for <select> box without name attribute

### DIFF
--- a/lib/HTML/FillInForm.pm
+++ b/lib/HTML/FillInForm.pm
@@ -321,7 +321,7 @@ sub start {
     $self->{output} .= ' /' if $attr->{'/'};
     $self->{output} .= ">";
   } elsif ($tagname eq 'option'){
-    my $value = $self->_get_param($self->{selectName});
+    my $value = defined($self->{selectName}) ? $self->_get_param($self->{selectName}) : undef;
 
     # browsers do not pass selects with no selected options at all,
     # so hack around


### PR DESCRIPTION
Modern forms sometimes contain <select> boxes with no name, since their
value is not intended to be submitted with the form (but rather used by
Javascript via the <select> DOM ID).

If HTML::FillInForm encounters such a <select> box, selectName will be
undefined when handling the <option> tag and the current code will try
to call $self->_get_param(undef).

If $self->_get_param(undef) is called with an fobject tied to a
Catalyst::Request, it will carp a warning about asking for an undefined
parameter.

This patch fixes the issue.

Signed-off-by: Chase Venters <chase.venters@chaseventers.com>